### PR TITLE
Replicate "end" event from connection to input

### DIFF
--- a/src/React/Stomp/Factory.php
+++ b/src/React/Stomp/Factory.php
@@ -43,6 +43,10 @@ class Factory
             $input->emit('error', array($e));
         });
 
+        $conn->on('end', function ($e) use ($input) {
+            $input->emit('end', array($e));
+        });
+
         return new Client($this->loop, $input, $output, $options);
     }
 


### PR DESCRIPTION
Fixes https://github.com/reactphp/stomp/issues/24 without throwing exception as in https://github.com/reactphp/stomp/pull/25